### PR TITLE
Disable default switcher on edit state

### DIFF
--- a/administrator/components/com_content/Helper/ContentHelper.php
+++ b/administrator/components/com_content/Helper/ContentHelper.php
@@ -58,13 +58,13 @@ class ContentHelper extends \JHelperContent
 				$workflowID = $app->getUserStateFromRequest('filter.workflow_id', 'workflow_id', 1, 'int');
 
 				\JHtmlSidebar::addEntry(
-					\JText::_('COM_WORKFLOW_STATE'),
+					\JText::_('COM_WORKFLOW_STATES'),
 					'index.php?option=com_workflow&view=states&workflow_id=' . $workflowID . "&extension=com_content",
 					$vName == 'states`'
 				);
 
 				\JHtmlSidebar::addEntry(
-					\JText::_('COM_WORKFLOW_TRANSITION'),
+					\JText::_('COM_WORKFLOW_TRANSITIONS'),
 					'index.php?option=com_workflow&view=transitions&workflow_id=' . $workflowID . "&extension=com_content",
 					$vName == 'transitions'
 				);

--- a/administrator/components/com_workflow/Model/Workflow.php
+++ b/administrator/components/com_workflow/Model/Workflow.php
@@ -138,17 +138,20 @@ class Workflow extends Admin
 			}
 		}
 
-		// Alter the title for save as copy
 		if ($input->get('task') == 'save2copy')
 		{
 			$origTable = clone $this->getTable();
 			$origTable->load($input->getInt('id'));
 
+			// Alter the title for save as copy
 			if ($data['title'] == $origTable->title)
 			{
 				list($title, $alias) = $this->generateNewTitle(0, '', $data['title']);
 				$data['title'] = $title;
 			}
+
+			// Unpublish new copy
+			$data['published'] = 0;
 		}
 
 		$result = parent::save($data);


### PR DESCRIPTION
### Summary of Changes
This PR disables the default switcher on edit state if the state is default. 


### Testing Instructions
Open a state which is default. 
Switch the default-switcher to "no".
Save the state.
You will get an Errormessage - see screen below, and the state is not saved.

Apply the patch and repeat the test.
You cannot switch to default "no". 

### Expected result
Expected is a warning that it is not possible to remove the default state. Because there must be a default state.
But it seems more convenient if the switch is disabled, So there is no need for warning - "don't make me think!".

NOTE: The switcher is disabled but at the moment it does not look disabled because the switcher does not support the disabled attribute. This will be fixed soon. 

### Actual result
![default-switcher](https://user-images.githubusercontent.com/1035262/30253786-54b460c6-968c-11e7-8a3c-8c060c3ca1f2.PNG)


### Documentation Changes Required
No
